### PR TITLE
Add Render deployment configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,9 @@
+services:
+  - type: web
+    name: healthcare-dashboard
+    runtime: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn src.app:server
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.11.11"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 dash==2.14.0
-pandas==2.0.3
+dash-vega-components
+pandas
 altair==5.1.2
 vega-datasets==0.9.0
 gunicorn==21.2.0


### PR DESCRIPTION
## Changes

- Add `render.yaml` for Render web service deployment (Python 3.11, gunicorn)
- Add missing `dash-vega-components` dependency to `requirements.txt`
- Unpin pandas version for broader compatibility

## Deployment

After merging, connect the repo to [Render](https://render.com) and set:
- **Build Command**: `pip install -r requirements.txt`
- **Start Command**: `gunicorn src.app:server`